### PR TITLE
Add report folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 _build/
 build/
 dist/
+reports/


### PR DESCRIPTION
Reports folder are created during test execution. This folder is not tracked by repository and can be accidentally added after CI/CD workflow, when the branch merge is tested.